### PR TITLE
fix: loading with commonJS require

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Asynchronous stream transforms",
   "type": "module",
   "module": "./lib/transforms.js",
-  "main": "./require/transforms.cjs",
+  "main": "./require/index.cjs",
   "types": "src/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
Without this change I cannot require the package as it returns the following error:

> Error: Cannot find module '/.../node_modules/async-transforms/require/transforms.cjs'. Please verify that the package.json has a valid "main" entry